### PR TITLE
fix typo: 'topt' and chore improvements

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,39 @@
+# This workflow will do a clean install of node dependencies, run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on: [push, pull_request]
+
+jobs:
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm test
+
+  # coverage:
+  #   needs: [ test ]
+  #   name: coverage
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@master
+  #   - uses: actions/setup-node@master
+  #     with:
+  #       node-version: '12'
+  #   - run: npm ci
+  #   - uses: paambaati/codeclimate-action@v2.7.5
+  #     env:
+  #       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+  #     with:
+  #       coverageCommand: npm run coverage

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ The setup requires the addition of a single hook to the authentication service, 
 
 ## Backend Implementation
 
-Just add the `topt2fa` hook of this package to the _after_ hooks of the `create` method in the `authentication` service, e.g.:
+Just add the `totp2fa` hook of this package to the _after_ hooks of the `create` method in the `authentication` service, e.g.:
 
 ```js
 const {
@@ -18,7 +18,7 @@ const {
 const { LocalStrategy } = require("@feathersjs/authentication-local");
 const { expressOauth } = require("@feathersjs/authentication-oauth");
 
-const { topt2fa } = require("feathers-totp-2fa").hooks;
+const { totp2fa } = require("feathers-totp-2fa").hooks;
 
 module.exports = (app) => {
   const authentication = new AuthenticationService(app);
@@ -29,16 +29,16 @@ module.exports = (app) => {
   app.use("/authentication", authentication);
   app.configure(expressOauth());
 
-  // TOPT 2FA Hook
+  // TOTP 2FA Hook
   app.service("authentication").hooks({
     after: {
-      create: [topt2fa()],
+      create: [totp2fa()],
     },
   });
 };
 ```
 
-The `topt2fa` hook can be invoked with the following options:
+The `totp2fa` hook can be invoked with the following options:
 
 - `usersService`: the name of the users service (default: `users`),
 
@@ -51,10 +51,10 @@ The `topt2fa` hook can be invoked with the following options:
 For example:
 
 ```js
- // TOPT 2FA Hook
+ // TOTP 2FA Hook
 app.service("authentication").hooks({
     after: {
-      create: [topt2fa({
+      create: [totp2fa({
           usersService: "users",
           secretFieldName: "totp2faSecret",
           requiredFieldName: "totp2faRequired",
@@ -97,7 +97,7 @@ The setup phase starts with the frontend sending a normal sign-in request to the
 }
 ```
 
-Feathers will authenticate the user, i. e. generate a JWT and add it to the response object. After this, the `topt2fa` hook will be invoked and check if TOTP 2FA is required for this user and if so, it will check if a TOTP secret has already been stored in the user data. If there is already a secret, the hook will trigger a 403 error `Token required.`, and the frontend has to ask the user for this token (see next section). Otherwise, the `topt2fa` hook generates a TOTP secret and a QR code image containing the auth path with this secret and adds it to the response to the client/frontend (2):
+Feathers will authenticate the user, i. e. generate a JWT and add it to the response object. After this, the `totp2fa` hook will be invoked and check if TOTP 2FA is required for this user and if so, it will check if a TOTP secret has already been stored in the user data. If there is already a secret, the hook will trigger a 403 error `Token required.`, and the frontend has to ask the user for this token (see next section). Otherwise, the `totp2fa` hook generates a TOTP secret and a QR code image containing the auth path with this secret and adds it to the response to the client/frontend (2):
 
 ```json
 {
@@ -120,7 +120,7 @@ The frontend sends the secret together with the token back to the authentication
 }
 ```
 
-The `topt2fa` hook verifies the token and stores the secret in the user data. Finally, the backend responses with the normal JWT (6).
+The `totp2fa` hook verifies the token and stores the secret in the user data. Finally, the backend responses with the normal JWT (6).
 
 ### Operation phase
 
@@ -140,7 +140,7 @@ The frontend sends a normal sign-in request to the Feathers app (1). For example
 }
 ```
 
-Feathers will authenticate the user, i. e. generate a JWT and add it to the response object. After this, the `topt2fa` hook checks if TOTP is required for this user, and if so, it will check if a TOTP secret has already been stored in the user data. If so, it will check if a valid token is part of the frontend request.
+Feathers will authenticate the user, i. e. generate a JWT and add it to the response object. After this, the `totp2fa` hook checks if TOTP is required for this user, and if so, it will check if a TOTP secret has already been stored in the user data. If so, it will check if a valid token is part of the frontend request.
 
 If the token is missing, the hook will trigger a `Token required` error (2). Otherwise the hook will continue with the final step (6).
 
@@ -157,4 +157,4 @@ The user enters the token from the app, and the frontend sends the normal creden
 }
 ```
 
-If the `topt2fa` hook verifies this token, the backend will respond with the normal JWT (6).
+If the `totp2fa` hook verifies this token, the backend will respond with the normal JWT (6).

--- a/src/hooks/totp2fa.ts
+++ b/src/hooks/totp2fa.ts
@@ -6,7 +6,7 @@ import getQrCodeSecret from "../utils/get-qr-code-secret";
 import verifyToken from "../utils/verify-token";
 import { defaultOptions } from "../options";
 
-import type { Options } from "../types";
+import type { TotpOptions } from "../types";
 
 /**
  * TOTP 2FA Hook
@@ -14,7 +14,7 @@ import type { Options } from "../types";
  * To be called in the after hook of the create method in the authentication service
  */
 export default function totp2fa(
-  options?: Options
+  options?: TotpOptions
 ): (context: HookContext) => HookContext {
   return async (context: HookContext): HookContext => {
     options = Object.assign(defaultOptions, options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import topt2fa from "./hooks/totp2fa";
+import totp2fa from "./hooks/totp2fa";
 
 export const hooks = {
-  topt2fa,
+  totp2fa,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,7 @@ import totp2fa from "./hooks/totp2fa";
 export const hooks = {
   totp2fa,
 };
+
+export { totp2fa };
+
+export * from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export type User = {
   base32secret: string;
 };
 
-export interface Options {
+export interface TotpOptions {
   usersService: string;
   secretFieldName: string;
   requiredFieldName: string;

--- a/src/utils/get-qr-code-secret.ts
+++ b/src/utils/get-qr-code-secret.ts
@@ -2,12 +2,12 @@ import { authenticator } from "otplib";
 import qrcode from "qrcode";
 
 import type { Application } from "@feathersjs/feathers";
-import type { User, Options, QrImageSecret } from "../types";
+import type { User, TotpOptions, QrImageSecret } from "../types";
 
 export default async function getQrCodeSecret(
   app: Application,
   user: User,
-  options: Options
+  options: TotpOptions
 ): Promise<QrImageSecret> {
   // Get secret (base32 encoded)
   const secret = user[options.secretFieldName]


### PR DESCRIPTION
Again, thanks for this package! I cannot wait to add this anytime soon to my app.
I added my two cents:
- change 'topt' to 'totp'
- export hook on root at entry file -> better [cherry picking](https://developers.google.com/web/fundamentals/performance/optimizing-javascript/tree-shaking) for esm-module
- export types on entry file `export * from "./types"`: types from packages come in handy sometimes, like `import { Application } from "@feathersjs/feathers"`
- added github action

I'm happy to discuss these points or explain more if needed. Please feel free to refuse changes, if you feel like.